### PR TITLE
comments api 관련 로직을 추상화합니다.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint:code-fix": "eslint --fix --ext .js,.jsx",
     "lint:output-html": "npx eslint --ext .js,.jsx . -f html -o eslint-result.html --quiet",
     "prettier:code-fix": "prettier --write",
-    "api": "json-server --watch db.json"
+    "api": "json-server --watch db.json --port 4000"
   },
   "dependencies": {
     "@emotion/react": "^11.10.4",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@emotion/react": "^11.10.4",
     "@emotion/styled": "^11.10.4",
+    "axios": "^0.27.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.3.0"

--- a/src/api/commentsApiService.js
+++ b/src/api/commentsApiService.js
@@ -1,0 +1,41 @@
+import BaseApiService from '@/api/core';
+
+class CommentsApiService extends BaseApiService {
+  constructor() {
+    super('comments');
+  }
+
+  getComments = ({ page = 1, limit = 10 } = {}) =>
+    this.http
+      .get(`?_page=${page}&_limit=${limit}`)
+      .then(BaseApiService.handleResponse)
+      .catch(BaseApiService.handleError);
+
+  getComment = ({ commentId } = {}) =>
+    this.http
+      .get(`/${commentId}`)
+      .then(BaseApiService.handleResponse)
+      .catch(BaseApiService.handleError);
+
+  createComment = ({ comment: { profileUrl, author, content, createdAt } } = { comment: {} }) =>
+    this.http
+      .post('', { profileUrl, author, content, createdAt })
+      .then(BaseApiService.handleResponse)
+      .catch(BaseApiService.handleError);
+
+  updateComment = ({ commentId, comment } = {}) => {
+    const { profileUrl, author, content, createdAt } = comment;
+    return this.http
+      .put(`/${commentId}`, { profileUrl, author, content, createdAt })
+      .then(BaseApiService.handleResponse)
+      .catch(BaseApiService.handleError);
+  };
+
+  deleteComment = ({ commentId } = {}) =>
+    this.http
+      .delete(`/${commentId}`)
+      .then(BaseApiService.handleResponse)
+      .catch(BaseApiService.handleError);
+}
+
+export default new CommentsApiService();

--- a/src/api/core.js
+++ b/src/api/core.js
@@ -1,0 +1,33 @@
+import axios from 'axios';
+
+const BASE_URL = 'http://localhost:4000';
+
+class BaseApiService {
+  constructor(path) {
+    this.http = axios.create({
+      baseURL: `${BASE_URL}/${path ?? ''}`,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+  }
+
+  static handleResponse = response => response.data;
+
+  static handleError(error) {
+    if (error instanceof Error) {
+      if (axios.isAxiosError(error)) {
+        if (error.response) {
+          throw error;
+        } else if (error.request) {
+          throw new Error(error);
+        }
+      } else {
+        throw new Error(error.message);
+      }
+    }
+    throw new Error(error);
+  }
+}
+
+export default BaseApiService;

--- a/src/pages/Home/Home.jsx
+++ b/src/pages/Home/Home.jsx
@@ -1,21 +1,29 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import CommentList from '@/components/home/CommentList/CommentList';
 import Form from '@/components/home/Form/Form';
 import PageList from '@/components/home/PageList/PageList';
+import commentsApiService from '@/api/commentsApiService';
 
 const Home = () => {
-  const dummyCommentList = [
-    {
-      id: 1,
-      profile_url: 'https://picsum.photos/id/1/50/50',
-      author: 'abc_1',
-      content: 'UI 테스트는 어떻게 진행하나요',
-      createdAt: '2020-05-01',
-    },
-  ];
+  const [commentList, setCommentList] = useState([]);
+
+  useEffect(() => {
+    const fetchComments = async () => {
+      try {
+        const commentsResponse = await commentsApiService.getComments();
+
+        setCommentList(commentsResponse);
+      } catch (error) {
+        throw new Error(error);
+      }
+    };
+
+    fetchComments();
+  }, []);
+
   return (
     <>
-      <CommentList commentList={dummyCommentList} />
+      <CommentList commentList={commentList} />
       <PageList />
       <Form />
     </>

--- a/yarn.lock
+++ b/yarn.lock
@@ -672,10 +672,23 @@ astral-regex@^2.0.0:
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
   integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
 
+asynckit@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
+
 axe-core@^4.4.3:
   version "4.4.3"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.4.3.tgz#11c74d23d5013c0fa5d183796729bc3482bd2f6f"
   integrity sha512-32+ub6kkdhhWick/UjvEwRchgoetXqTK14INLqbGm5U2TzBkBNF3nQtLYm8ovxSkQWArjEQvftCKryjZaATu3w==
+
+axios@^0.27.2:
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.27.2.tgz#207658cc8621606e586c85db4b41a750e756d972"
+  integrity sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==
+  dependencies:
+    follow-redirects "^1.14.9"
+    form-data "^4.0.0"
 
 axobject-query@^2.2.0:
   version "2.2.0"
@@ -906,6 +919,13 @@ colorette@^2.0.16, colorette@^2.0.17:
   resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.19.tgz#cdf044f47ad41a0f4b56b3a0d5b4e6e1a2d5a798"
   integrity sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==
 
+combined-stream@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+  dependencies:
+    delayed-stream "~1.0.0"
+
 commander@^9.3.0:
   version "9.4.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-9.4.0.tgz#bc4a40918fefe52e22450c111ecd6b7acce6f11c"
@@ -1092,6 +1112,11 @@ define-properties@^1.1.3, define-properties@^1.1.4:
   dependencies:
     has-property-descriptors "^1.0.0"
     object-keys "^1.1.1"
+
+delayed-stream@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
 depd@2.0.0, depd@~2.0.0:
   version "2.0.0"
@@ -1757,6 +1782,20 @@ flatted@^3.1.0:
   version "3.2.7"
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.7.tgz#609f39207cb614b89d0765b477cb2d437fbf9787"
   integrity sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==
+
+follow-redirects@^1.14.9:
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
+  integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 forwarded@0.2.0:
   version "0.2.0"
@@ -2566,7 +2605,7 @@ mime-db@1.52.0, "mime-db@>= 1.43.0 < 2":
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
-mime-types@~2.1.24, mime-types@~2.1.34:
+mime-types@^2.1.12, mime-types@~2.1.24, mime-types@~2.1.34:
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==


### PR DESCRIPTION
## 변경사항
- axios 의존성을 추가합니다.
- axios.create를 이용하여 http통신을 위한 인스턴스를 생성하고 해당 인스턴스로 api로직을 추상화해주었습니다.
- json-server의 기본 포트를 4000번으로 수정하였습니다.

### api 사용법
```sh
# 의존성 설치
yarn install

# json-server 실행
yarn api

# react project 실행
yarn dev
```

### getComments api사용시 페이지네이션 사용법
```js
// api를 정의한 로직에서 default 값으로 page: 1, limit: 10으로 다루고 있습니다.

// 10개씩 데이터를 들고오되 2번째 페이지의 데이터를 가져올때
// 즉, index 10 ~ 19까지의 데이터를 가져올때의 예시
commentsApiService.getComments({page: 2, limit: 10});
```